### PR TITLE
fixed Tooltip.css import error

### DIFF
--- a/eg-tracks/src/components/GenomeView/TrackComponents/commonComponents/MetadataIndicator.tsx
+++ b/eg-tracks/src/components/GenomeView/TrackComponents/commonComponents/MetadataIndicator.tsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 import TrackModel from "../../../../models/TrackModel";
 
-import "./hoverToolTips/Tooltip.css";
+import "./HoverToolTips/Tooltip.css";
 import { variableIsObject } from "../../../../models/util";
 
 /*

--- a/eg-tracks/src/components/GenomeView/TrackComponents/commonComponents/annotation/FeatureDetail.tsx
+++ b/eg-tracks/src/components/GenomeView/TrackComponents/commonComponents/annotation/FeatureDetail.tsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 import React from "react";
 import _ from "lodash";
 import Feature from "../../../../../models/Feature";
-import "../hoverToolTips/Tooltip.css";
+import "../HoverToolTips/Tooltip.css";
 import { CopyToClip } from "../CopyToClipboard";
 
 /**
@@ -42,9 +42,8 @@ class FeatureDetail extends React.PureComponent<FeatureDetailProps> {
             </a>
           );
         } else {
-          const ncbiURL = `https://www.ncbi.nlm.nih.gov/gene/?term=${
-            feature.id.split(".")[0]
-          }`;
+          const ncbiURL = `https://www.ncbi.nlm.nih.gov/gene/?term=${feature.id.split(".")[0]
+            }`;
           linkOut = (
             <a href={ncbiURL} target="_blank" rel="noopener noreferrer">
               NCBI


### PR DESCRIPTION
So, I cloned the repo and tried running it and got import errors: 

```
7:20:53 PM [vite] Pre-transform error: Failed to resolve import "./hoverToolTips/Tooltip.css" from "../eg-tracks/src/components/GenomeView/TrackComponents/commonComponents/MetadataIndicator.tsx". Does the file exist?
```

So, I fixed the imports, this should let everyone run the browser without any errors. 